### PR TITLE
static bigscreen layout for fixed sequence of applications

### DIFF
--- a/examples/nnako.pyw
+++ b/examples/nnako.pyw
@@ -1,0 +1,187 @@
+from jmk import hks
+from log import *
+
+from jigsawwm import daemon, ui
+from jigsawwm.tiler import tilers
+from jigsawwm.w32.vk import Vk
+from jigsawwm.w32.window import inspect_active_window
+from jigsawwm.wm import Theme, WindowManager
+
+
+#
+# CONCEPT
+#
+
+# +----------+----------+----------+----------+
+# |          |          |          |          |
+# |          |          |          |          |
+# |     1    |     2    |     3    |          |
+# |          |          |          |          |
+# |          |          |          |          |
+# +----------+--+-----+-+----------+          |
+# |             |     |            |          |
+# |             |     |            |          |
+# |             |     |            |          |
+# |             |     |            |     4    |
+# |             |  6  |      7     |          |
+# |     5       |     |            |          |
+# |             |     |            |          |
+# |             |     |            |          |
+# |             +-----+------------|          |
+# |             |                  |          |
+# |             |         8        |          |
+# +-------------+------------------+----------+
+
+# IDX  LAYER1            LAYER2   LAYER3
+# ---------------------------------------------
+# 1    OUTLOOK           TEAMS    SSH / MUTT
+# 2    TOTAL COMMANDER
+# 3    EXCEL PLAN        yED
+# 4    FREEPLANE
+# 5    CHROME
+# 6    NOTEPAD++
+# 7    NEOVIM
+# 8    CMD
+
+
+#
+# define window manager
+#
+
+wm = WindowManager(
+    themes=[
+        # Theme(
+        #     name="OBS Dwindle",
+        #     layout_tiler=tilers.obs_dwindle_layout_tiler,
+        #     icon_name="obs.png",
+        #     gap=2,
+        #     strict=True,
+        # ),
+        Theme(
+            name="static_bigscreen_8",
+            layout_tiler=tilers.static_bigscreen_8_layout_tiler,
+            strict=True,
+            gap=2,
+            new_window_as_master=True,
+        ),
+        Theme(
+            name="Dwindle",
+            layout_tiler=tilers.dwindle_layout_tiler,
+            strict=True,
+            gap=2,
+            new_window_as_master=True,
+        ),
+        Theme(
+            name="WideScreen Dwindle",
+            layout_tiler=tilers.widescreen_dwindle_layout_tiler,
+            icon_name="wide-dwindle.png",
+            gap=2,
+            strict=True,
+            new_window_as_master=True,
+        ),
+        Theme(
+            name="Mono",
+            layout_tiler=tilers.mono_layout_tiler,
+            strict=True,
+        ),
+    ],
+    ignore_exe_names=[
+        "ApplicationFrameHost.exe", # ?
+#        "chrome.exe",               # Chrome web browser
+#        "Cloudflare WARP.exe",
+#        "cmd.exe",                  # cmd consoles
+#        "EXCEL.EXE",
+        "explorer.exe",             # ?
+#        "freeplane.exe",            # mindmap editor
+#        "javaw.exe",                # mindmap editor
+#        "MediaInfo.exe",
+        "mintty.exe",               # ?
+        "msedge.exe",               # browser
+#        "notepad++.exe",            # text editor
+#        "openvpn-gui.exe",
+        "OUTLOOK.EXE",
+        "SnagitCapture.exe",
+        "SnagitEditor.exe",
+        "SnippingTool.exe",
+#        "Teams.exe",
+        "TOTALCMD.EXE",
+#        "yEd.exe",
+        ],
+    force_managed_exe_names=["Lens.exe"],
+
+    # here the wished initial sequence of applications in order to correctly
+    # fill the windows. these applications will not be ignored, so they don't
+    # need to be listed within the ignore_exe_names list.
+    init_exe_sequence=[
+            ["cmd.exe", "nvim"],            # code editor
+            ["cmd.exe", ""],                # debug console
+            ["notepad++.exe", ""],          # general text editor
+            ["javaw.exe", "freeplane"],     # mindmap editor
+            ["chrome.exe", ""],             # internet browser
+            ["Teams.exe", ""],              # messaging
+            ["yEd.exe", ""],                # diagramming
+            ["EXCEL.EXE", ""],              # organizational stuff
+            ],
+)
+
+
+#
+# define hotkeys
+#
+
+hotkeys = [
+    ([Vk.WIN, Vk.J], wm.activate_next, ui.hide_windows_splash),
+    ([Vk.WIN, Vk.K], wm.activate_prev, ui.hide_windows_splash),
+    ([Vk.WIN, Vk.SHIFT, Vk.J], wm.swap_next),
+    ([Vk.WIN, Vk.SHIFT, Vk.K], wm.swap_prev),
+    ("Win+/", wm.set_master),
+    ([Vk.WIN, Vk.SPACE], wm.next_theme),
+    ([Vk.WIN, Vk.U], wm.prev_monitor),
+    ([Vk.WIN, Vk.I], wm.next_monitor),
+    ([Vk.WIN, Vk.SHIFT, Vk.U], wm.move_to_prev_monitor),
+    ([Vk.WIN, Vk.SHIFT, Vk.I], wm.move_to_next_monitor),
+    ([Vk.WIN, Vk.CONTROL, Vk.I], inspect_active_window),
+]
+
+
+class WindowManagerService(daemon.Service):
+    name = "Window Manager"
+    is_running = False
+
+    def start(self):
+        self.is_running = True
+
+        #
+        # install hooks
+        #
+
+        wm.install_hooks()
+
+        #
+        # register hotkeys
+        #
+
+        for args in hotkeys:
+            hks.register(*args)
+
+    def stop(self):
+
+        #
+        # uninstall hooks
+        #
+
+        wm.uninstall_hooks()
+
+        #
+        # register hotkeys
+        #
+
+        for args in hotkeys:
+            hks.unregister(args[0])
+        self.is_running = False
+
+
+daemon.register(WindowManagerService)
+
+if __name__ == "__main__":
+    daemon.message_loop()

--- a/src/jigsawwm/tiler/layouts.py
+++ b/src/jigsawwm/tiler/layouts.py
@@ -75,6 +75,93 @@ def dwindle(n: int) -> Iterator[FloatRect]:
             t = nb
 
 
+def static_bigscreen_8(n: int) -> Iterator[FloatRect]:
+    """layout for a big screen (like a television) of 55 inches or more. here,
+    the 'eye line' should define the upper (main) horizontal segregation. due
+    to an attempt keep the eyes below it for main actions on the screen. the
+    screen will be optimal for 8 application windows. fewer windows might lead
+    to a different layout.
+
+    .. code-block:: text
+
+    +----------+----------+----------+----------+
+    |          |          |          |          |
+    |          |          |          |          |
+    |     6    |     7    |     8    |          |
+    |          |          |          |          |
+    |          |          |          |          |
+    +----------+--+-----+-+----------+          |
+    |             |     |            |          |
+    |             |     |            |          |
+    |             |     |            |          |
+    |             |     |            |     4    |
+    |             |  3  |      1     |          |
+    |     5       |     |            |          |
+    |             |     |            |          |
+    |             |     |            |          |
+    |             +-----+------------|          |
+    |             |                  |          |
+    |             |         2        |          |
+    +-------------+------------------+----------+
+
+    :param n: total number of currently active windows
+    :rtype: Iterator[FloatRect]
+    """
+
+    # one single window fills the whole screen
+    l, t, r, b = 0.0, 0.0, 1.0, 1.0
+    h1 = 0.37
+    h2 = 0.80
+    v1 = 0.30
+    v2 = 0.45
+
+    # one window present
+    if n==1:
+        yield 0.25, 0.37, 0.75, 1.00
+    if n==2:
+        yield 0.25, 0.37, 0.75, 0.80
+        yield 0.25, 0.80, 0.75, 1.00
+    if n==3:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+    if n==4:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+        yield 0.75, 0.00, 1.00, 1.00
+    if n==5:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+        yield 0.75, 0.00, 1.00, 1.00
+        yield 0.00, 0.37, 0.30, 1.00
+    if n==6:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+        yield 0.75, 0.00, 1.00, 1.00
+        yield 0.00, 0.37, 0.30, 1.00
+        yield 0.00, 0.00, 0.25, 0.37
+    if n==7:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+        yield 0.75, 0.00, 1.00, 1.00
+        yield 0.00, 0.37, 0.30, 1.00
+        yield 0.00, 0.00, 0.25, 0.37
+        yield 0.25, 0.00, 0.50, 0.37
+    if n==8:
+        yield 0.45, 0.37, 0.75, 0.80
+        yield 0.30, 0.80, 0.75, 1.00
+        yield 0.30, 0.37, 0.45, 0.80
+        yield 0.75, 0.00, 1.00, 1.00
+        yield 0.00, 0.37, 0.30, 1.00
+        yield 0.00, 0.00, 0.25, 0.37
+        yield 0.25, 0.00, 0.50, 0.37
+        yield 0.50, 0.00, 0.75, 0.37
+
+
 def widescreen_dwindle(n: int, master_ratio: float = 0.4) -> Iterator[FloatRect]:
     """A wide-screen friendly dwindle Layout
 

--- a/src/jigsawwm/tiler/tilers.py
+++ b/src/jigsawwm/tiler/tilers.py
@@ -11,7 +11,7 @@ The ``tiler`` module is responsible for converting Layout to Physical Coordinate
 """
 from typing import Callable, Iterator, Tuple
 
-from .layouts import Layout, dwindle, mono, plug_rect, widescreen_dwindle
+from .layouts import Layout, dwindle, mono, static_bigscreen_8, plug_rect, widescreen_dwindle
 
 # Rect holds physical coordinate for rectangle (left/top/right/bottom)
 Rect = Tuple[int, int, int, int]
@@ -101,6 +101,11 @@ def mono_layout_tiler(*args, **kwargs) -> Iterator[Rect]:
 def dwindle_layout_tiler(*args, **kwargs) -> Iterator[Rect]:
     """The dwindle layout tiler"""
     return direct_tiler(dwindle, *args, **kwargs)
+
+
+def static_bigscreen_8_layout_tiler(*args, **kwargs) -> Iterator[Rect]:
+    """The static bigscreen layout tiler for up to 8 windows"""
+    return direct_tiler(static_bigscreen_8, *args, **kwargs)
 
 
 def widescreen_dwindle_layout_tiler(*args, **kwargs) -> Iterator[Rect]:


### PR DESCRIPTION
This pull request implements the possibility to use static application sequences which is especially important when dealing with large screens (like 55 inch televisions). Using 8 applications always at the same positions within such a big screen can be a great productivity gain. Unfortunately, as the default initial order (sequence) of applications is not easily determined, the windows had to be moved around, teadiously, until the final setting could be achieved. Using this pull request, the user can simply set the argument "init_exe_sequence" when starting his preferred configuration file e.g. `nnako.pyw` from the examples folder.

Within this list structure, the desired sequence of applications as well as further identification specifics can be defined. Please see `nnako.pyw` for the intended usage.