### PR TITLE
fixes for handling of static themes

### DIFF
--- a/examples/nnako.pyw
+++ b/examples/nnako.pyw
@@ -1,41 +1,5 @@
 """An example for nnako"""
 
-#
-# CONCEPT
-#
-
-# +----------+----------+----------+----------+
-# |          |          |          |          |
-# |          |          |          |          |
-# |     5    |     6    |     7    |          |
-# |          |          |          |          |
-# |          |          |          |          |
-# +----------+--+-----+-+----------+          |
-# |             |     |            |          |
-# |             |     |            |          |
-# |             |     |            |          |
-# |             |     |            |     3    |
-# |             |  1  |      0     |          |
-# |     4       |     |            |          |
-# |             |     |            |          |
-# |             |     |            |          |
-# |             +-----+------------|          |
-# |             |                  |          |
-# |             |         2        |          |
-# +-------------+------------------+----------+
-
-# IDX  LAYER1            LAYER2     LAYER3
-# ---------------------------------------------
-# 0    NEOVIM
-# 1    CMD
-# 2    NOTEPAD++
-# 3    FREEPLANE
-# 4    CHROME
-# 5    TEAMS             OUTLOOK    SSH / MUTT
-# 6    yED
-# 7    EXCEL PLAN        TOTALCMD
-
-
 from functools import partial
 
 from jigsawwm.app.daemon import Daemon
@@ -47,50 +11,37 @@ from jigsawwm.wm.config import WmRule
 daemon = Daemon()
 
 daemon.wm.hotkeys = [
-    ([Vk.WIN, Vk.CTRL, Vk.J], daemon.wm.manager.next_window),
-    ([Vk.WIN, Vk.CTRL, Vk.K], daemon.wm.manager.prev_window),
-    ([Vk.WIN, Vk.SHIFT, Vk.J], daemon.wm.manager.swap_next),
-    ([Vk.WIN, Vk.SHIFT, Vk.K], daemon.wm.manager.swap_prev),
-    ("Win+Ctrl+/", daemon.wm.manager.set_master),
-    ([Vk.WIN, Vk.CONTROL, Vk.SPACE], daemon.wm.manager.next_theme),
-    ([Vk.WIN, Vk.U], daemon.wm.manager.prev_monitor),
-    ([Vk.WIN, Vk.I], daemon.wm.manager.next_monitor),
-    ([Vk.WIN, Vk.SHIFT, Vk.U], daemon.wm.manager.move_to_prev_monitor),
-    ([Vk.WIN, Vk.SHIFT, Vk.I], daemon.wm.manager.move_to_next_monitor),
-    ([Vk.WIN, Vk.CONTROL, Vk.I], daemon.wm.manager.inspect_active_window),
-    ("Win+Ctrl+a", partial(daemon.wm.manager.switch_to_workspace, 0)),
-    ("Win+Ctrl+s", partial(daemon.wm.manager.switch_to_workspace, 1)),
-    ("Win+Ctrl+d", partial(daemon.wm.manager.switch_to_workspace, 2)),
-    ("Win+Ctrl+f", partial(daemon.wm.manager.switch_to_workspace, 3)),
-    ("Win+Shift+a", partial(daemon.wm.manager.move_to_workspace, 0)),
-    ("Win+Shift+s", partial(daemon.wm.manager.move_to_workspace, 1)),
-    ("Win+Shift+d", partial(daemon.wm.manager.move_to_workspace, 2)),
-    ("Win+Shift+f", partial(daemon.wm.manager.move_to_workspace, 3)),
-    ("Win+Shift+Space", daemon.wm.manager.toggle_tilable),
-    ("Win+Ctrl+u", daemon.wm.manager.inspect_state),
-    (
-        "XBUTTON1+RBUTTON",
-        daemon.wm.manager.toggle_splash,
-    ),  # browser forward button + right button
+    ([Vk.WIN, Vk.CTRL, Vk.J],           daemon.wm.manager.next_window),
+    ([Vk.WIN, Vk.CTRL, Vk.K],           daemon.wm.manager.prev_window),
+    ([Vk.WIN, Vk.SHIFT, Vk.J],          daemon.wm.manager.swap_next),
+    ([Vk.WIN, Vk.SHIFT, Vk.K],          daemon.wm.manager.swap_prev),
+    ([Vk.WIN, Vk.CONTROL, Vk.SPACE],    daemon.wm.manager.next_theme),
+    ([Vk.WIN, Vk.CONTROL, Vk.I],        daemon.wm.manager.inspect_active_window),
+    ("Win+Ctrl+a", partial(             daemon.wm.manager.switch_to_workspace, 0)),
+    ("Win+Ctrl+s", partial(             daemon.wm.manager.switch_to_workspace, 1)),
+    ("Win+Ctrl+d", partial(             daemon.wm.manager.switch_to_workspace, 2)),
+    ("Win+Ctrl+f", partial(             daemon.wm.manager.switch_to_workspace, 3)),
+    ("Win+Shift+Space",                 daemon.wm.manager.toggle_tilable),
+    ("Win+Ctrl+u",                      daemon.wm.manager.inspect_state),
 ]
 
 daemon.wm.manager.config = WmConfig(
     rules=[
-    
+
         # list of application windows to be managed
-        WmRule(exe="cmd.exe", title="nvim", static_window_index=0),
-        WmRule(exe="cmd.exe", static_window_index=1),
-        WmRule(exe="notepad++.exe", static_window_index=2),
         WmRule(
-            exe="freeplane.exe",
-            title="freeplane",
-            static_window_index=3,
+            exe="WindowsTerminal.exe",
+            title="nvim",
+            static_window_index=0,
         ),
+        WmRule(exe="notepad++.exe", static_window_index=1),
+        WmRule(exe="WindowsTerminal.exe", static_window_index=2),
+        WmRule(exe="freeplane.exe", static_window_index=3),
         WmRule(exe="chrome.exe", static_window_index=4),
         WmRule(exe="ms-teams.exe", static_window_index=5),
         WmRule(exe="yEd.exe", static_window_index=6),
         WmRule(exe="EXCEL.EXE", static_window_index=7),
-        
+
         # list of application windows not to be regarded
         WmRule(exe="Len.exe", manageable=False),
         WmRule(exe="ApplicationFrameHost.exe", manageable=False),
@@ -103,6 +54,7 @@ daemon.wm.manager.config = WmConfig(
         WmRule(exe="SnagitEditor.exe", manageable=False),
         WmRule(exe="SnippingTool.exe", manageable=False),
         WmRule(exe="TOTALCMD.exe", manageable=False),
+        WmRule(exe="SourceTree.exe", manageable=False),
     ],
 )
 

--- a/src/jigsawwm/tiler/layouts.py
+++ b/src/jigsawwm/tiler/layouts.py
@@ -148,7 +148,7 @@ def static_bigscreen_8(n: int) -> Iterator[FloatRect]:
     v1 = 0.30
     v2 = 0.45
 
-    # one window present
+    # number of windows as parameter
     if n == 1:
         yield 0.25, 0.37, 0.75, 1.00
     if n == 2:
@@ -185,14 +185,14 @@ def static_bigscreen_8(n: int) -> Iterator[FloatRect]:
         yield 0.00, 0.00, 0.25, 0.37
         yield 0.25, 0.00, 0.50, 0.37
     if n == 8:
-        yield 0.45, 0.37, 0.75, 0.80
-        yield 0.30, 0.80, 0.75, 1.00
-        yield 0.30, 0.37, 0.45, 0.80
-        yield 0.75, 0.00, 1.00, 1.00
-        yield 0.00, 0.37, 0.30, 1.00
-        yield 0.00, 0.00, 0.25, 0.37
-        yield 0.25, 0.00, 0.50, 0.37
-        yield 0.50, 0.00, 0.75, 0.37
+        yield 0.45, 0.37, 0.75, 0.86    # 0
+        yield 0.25, 0.86, 0.75, 1.00    # 1
+        yield 0.25, 0.37, 0.45, 0.86    # 2
+        yield 0.75, 0.00, 1.00, 1.00    # 3
+        yield 0.00, 0.37, 0.25, 1.00    # 4
+        yield 0.00, 0.00, 0.25, 0.37    # 5
+        yield 0.25, 0.00, 0.50, 0.37    # 6
+        yield 0.50, 0.00, 0.75, 0.37    # 7
 
 
 def widescreen_dwindle(n: int, master_ratio: float = 0.4) -> Iterator[FloatRect]:

--- a/src/jigsawwm/wm/config.py
+++ b/src/jigsawwm/wm/config.py
@@ -36,11 +36,9 @@ class WmRule:
         tilable: Optional[bool] = None,
     ):
         if exe:
-            self.exe_regex = self.parse_pattern(exe, exe_is_literal, exact=True)
+            self.exe_regex = self.parse_pattern(exe, exe_is_literal)
         if title:
-            # Literal titles are treated as case-insensitive substring matches,
-            # which is more practical for dynamic window titles.
-            self.title_regex = self.parse_pattern(title, title_is_literal, exact=False)
+            self.title_regex = self.parse_pattern(title, title_is_literal)
         self.exe_and_title = exe_and_title
         self.preferred_monitor_index = preferred_monitor_index
         self.preferred_workspace_index = preferred_workspace_index
@@ -49,12 +47,10 @@ class WmRule:
         self.tilable = tilable
 
     @staticmethod
-    def parse_pattern(pattern: str, literal: bool, exact: bool = True) -> re.Pattern:
+    def parse_pattern(pattern: str, literal: bool) -> re.Pattern:
         """Parse regex pattern"""
         if literal:
-            pattern = re.escape(pattern)
-            if exact:
-                pattern = r"\b" + pattern + r"$"
+            pattern = r"\b" + re.escape(pattern) + r"$"
         return re.compile(pattern, re.I)
 
     @staticmethod

--- a/src/jigsawwm/wm/config.py
+++ b/src/jigsawwm/wm/config.py
@@ -36,9 +36,11 @@ class WmRule:
         tilable: Optional[bool] = None,
     ):
         if exe:
-            self.exe_regex = self.parse_pattern(exe, exe_is_literal)
+            self.exe_regex = self.parse_pattern(exe, exe_is_literal, exact=True)
         if title:
-            self.title_regex = self.parse_pattern(title, title_is_literal)
+            # Literal titles are treated as case-insensitive substring matches,
+            # which is more practical for dynamic window titles.
+            self.title_regex = self.parse_pattern(title, title_is_literal, exact=False)
         self.exe_and_title = exe_and_title
         self.preferred_monitor_index = preferred_monitor_index
         self.preferred_workspace_index = preferred_workspace_index
@@ -47,10 +49,12 @@ class WmRule:
         self.tilable = tilable
 
     @staticmethod
-    def parse_pattern(pattern: str, literal: bool) -> re.Pattern:
+    def parse_pattern(pattern: str, literal: bool, exact: bool = True) -> re.Pattern:
         """Parse regex pattern"""
         if literal:
-            pattern = r"\b" + re.escape(pattern) + r"$"
+            pattern = re.escape(pattern)
+            if exact:
+                pattern = r"\b" + pattern + r"$"
         return re.compile(pattern, re.I)
 
     @staticmethod

--- a/src/jigsawwm/wm/workspace_state.py
+++ b/src/jigsawwm/wm/workspace_state.py
@@ -154,6 +154,7 @@ class WorkspaceState:
         """ "Sort windows by static_index"""
         assert self.theme.max_tiling_areas > 1
         new_tiling_windows = [None] * self.theme.max_tiling_areas
+        overflow_windows = []
 
         for w in tiling_windows:
             if w is None:
@@ -161,12 +162,21 @@ class WorkspaceState:
             if STATIC_WINDOW_INDEX in w.attrs:
                 static_index = w.attrs[STATIC_WINDOW_INDEX]
                 assert static_index < self.theme.max_tiling_areas
-                assert (
-                    new_tiling_windows[static_index] is None
-                ), "static index duplicated"
+                if new_tiling_windows[static_index] is not None:
+                    logger.warning(
+                        "static index %s duplicated for %s and %s; "
+                        "keeping the first assignment and treating the later "
+                        "window as overflow",
+                        static_index,
+                        new_tiling_windows[static_index],
+                        w,
+                    )
+                    overflow_windows.append(w)
+                    continue
                 new_tiling_windows[static_index] = w
             else:
-                new_tiling_windows.append(w)
+                overflow_windows.append(w)
+        new_tiling_windows.extend(overflow_windows)
         logger.info("new_tiling_windows: %s", new_tiling_windows)
         return new_tiling_windows
 

--- a/src/jigsawwm/wm/workspace_state.py
+++ b/src/jigsawwm/wm/workspace_state.py
@@ -220,7 +220,12 @@ class WorkspaceState:
             if window:
                 window.attrs[PREFERRED_WINDOW_INDEX] = i
         theme = self.theme
-        windows = list(w for w in self.tiling_windows if w and w.exists())
+        if theme.static_layout:
+            # Preserve empty slots so static_window_index keeps mapping to the
+            # same tiling area even when intermediate slots are unoccupied.
+            windows = list(self.tiling_windows)
+        else:
+            windows = [w for w in self.tiling_windows if w and w.exists()]
         # tile the first n windows
         n = len(windows)
         m = n
@@ -249,10 +254,11 @@ class WorkspaceState:
             self._stack_windows(work_rect, bound, windows, w=w, h=h)
         elif n == m and n > 0:
             w = windows[-1]
-            if w.handle == active_handle:
-                active_window, active_area = w, self.tiling_areas[-1]
-            else:
-                w.set_restricted_rect(self.tiling_areas[-1], work_rect)
+            if w is not None:
+                if w.handle == active_handle:
+                    active_window, active_area = w, self.tiling_areas[-1]
+                else:
+                    w.set_restricted_rect(self.tiling_areas[-1], work_rect)
         # bringing active window to the top
         if active_window and active_area:
             active_window.set_restricted_rect(active_area, work_rect)

--- a/tests/wm/test_config.py
+++ b/tests/wm/test_config.py
@@ -1,28 +1,27 @@
 """Test wm.config module."""
 
-from jigsawwm.wm.config import WmRule, WmConfig
+from types import SimpleNamespace
+
+from jigsawwm.wm.config import WmConfig, WmRule
 
 
-def test_find_rule(mocker):
-    """Test find_rule"""
-    config = WmConfig()
-    config.rules = [
-        WmRule(exe_regex=r"\bWindowsTerminal\.exe$", manageable=False),
-        WmRule(title_regex=r"Windows Terminal", tilable=False),
-    ]
-    config.prepare()
-    window = mocker.Mock()
-    window.exe = None
-    window.title = None
-    assert config.find_rule_for_window(window) is None
+def test_find_rule_for_window_terminal_title_specificity():
+    """A title-specific rule should win before a generic exe-only fallback."""
+    config = WmConfig(
+        rules=[
+            WmRule(exe="WindowsTerminal.exe", title="nvim", static_window_index=0),
+            WmRule(exe="WindowsTerminal.exe", static_window_index=1),
+        ]
+    )
 
-    window.exe = "WindowsTerminal.exe"
-    r = config.find_rule_for_window(window)
-    assert r.manageable is False
-    assert r.tilable is None
+    nvim_window = SimpleNamespace(
+        exe=r"C:\Program Files\WindowsApps\WindowsTerminal.exe",
+        title="notes - nvim - Windows Terminal",
+    )
+    shell_window = SimpleNamespace(
+        exe=r"C:\Program Files\WindowsApps\WindowsTerminal.exe",
+        title="PowerShell - Windows Terminal",
+    )
 
-    window.exe = None
-    window.title = "Windows Terminal"
-    r = config.find_rule_for_window(window)
-    assert r.manageable is None
-    assert r.tilable is False
+    assert config.find_rule_for_window(nvim_window).static_window_index == 0
+    assert config.find_rule_for_window(shell_window).static_window_index == 1

--- a/tests/wm/test_workspace_state.py
+++ b/tests/wm/test_workspace_state.py
@@ -1,0 +1,108 @@
+"""Tests for wm.workspace_state."""
+
+from jigsawwm.w32.window import Rect
+from jigsawwm.wm.theme import static_bigscreen_8
+from jigsawwm.wm.workspace_state import WorkspaceState
+
+
+class FakeMonitor:
+    """Minimal monitor stub for workspace tests."""
+
+    def __init__(self, work_rect: Rect):
+        self._work_rect = work_rect
+
+    def get_work_rect(self) -> Rect:
+        """Return the monitor work area used by the workspace."""
+        return self._work_rect
+
+
+class FakeWindow:
+    """Minimal tilable window stub for workspace tests."""
+
+    _next_handle = 1
+
+    def __init__(self, name: str, static_window_index: int):
+        self.name = name
+        self.attrs = {"static_window_index": static_window_index}
+        self.handle = FakeWindow._next_handle
+        FakeWindow._next_handle += 1
+        self.tilable = True
+        self.is_iconic = False
+        self.rects = []
+
+    def __hash__(self):
+        """Use the fake handle as the stable hash key."""
+        return hash(self.handle)
+
+    def __eq__(self, other):
+        """Compare fake windows by handle to mimic real windows."""
+        return isinstance(other, FakeWindow) and self.handle == other.handle
+
+    def exists(self):
+        """Report that the fake window is still available."""
+        return True
+
+    def get_rect(self):
+        """Return a placeholder rect used by workspace helpers."""
+        return Rect(0, 0, 100, 100)
+
+    def set_restricted_rect(self, rect, _work_rect, _insert_after=None):
+        """Capture the assigned tile rect for later assertions."""
+        self.rects.append(rect)
+
+
+def test_static_layout_preserves_sparse_static_slots(monkeypatch):
+    """Windows keep their configured static slot even when earlier slots are empty."""
+    monkeypatch.setattr(
+        "jigsawwm.wm.workspace_state.get_foreground_window",
+        lambda: None,
+    )
+    workspace = WorkspaceState(
+        monitor_index=0,
+        index=0,
+        name="0",
+        monitor=FakeMonitor(Rect(0, 0, 1000, 1000)),
+        alter_rect=Rect(0, 1200, 1000, 2200),
+        theme=static_bigscreen_8,
+    )
+    slot_0 = FakeWindow("slot-0", 0)
+    slot_2 = FakeWindow("slot-2", 2)
+    slot_5 = FakeWindow("slot-5", 5)
+
+    workspace.windows.update({slot_0, slot_2, slot_5})
+
+    workspace.sync_windows(force_arrange=True)
+
+    assert workspace.tiling_windows == [
+        slot_0,
+        None,
+        slot_2,
+        None,
+        None,
+        slot_5,
+        None,
+        None,
+    ]
+    assert len(workspace.tiling_areas) == static_bigscreen_8.max_tiling_areas
+    assert slot_0.rects == [workspace.tiling_areas[0]]
+    assert slot_2.rects == [workspace.tiling_areas[2]]
+    assert slot_5.rects == [workspace.tiling_areas[5]]
+
+
+def test_duplicate_static_index_is_treated_as_overflow():
+    """Duplicate static indices should not crash static sorting."""
+    workspace = WorkspaceState(
+        monitor_index=0,
+        index=0,
+        name="0",
+        monitor=FakeMonitor(Rect(0, 0, 1000, 1000)),
+        alter_rect=Rect(0, 1200, 1000, 2200),
+        theme=static_bigscreen_8,
+    )
+    first = FakeWindow("first", 1)
+    duplicate = FakeWindow("duplicate", 1)
+
+    ordered = workspace.sort_by_static_index([first, duplicate])
+
+    assert ordered[1] is first
+    assert ordered[-1] is duplicate


### PR DESCRIPTION
here are some fixes concerning the handling of big screens. basically the following subjects are covered (see commits for details):

- FIX: preserve window order within static themes
- FIX: prevent duplicate static window index values
- FIX: distinguish title-specific rules from generic executable rules
- NEW: add regression tests for static slot assignment and rule matching

please test with your own usecases, as I just tested mine.

this fixes makes the following functions work properly with static window layouts:

- jigsawwm.wm.manager.next_window()
- jigsawwm.wm.manager.prev_window()
- jigsawwm.wm.manager.swap_next()
- jigsawwm.wm.manager.swap_prev()